### PR TITLE
MaxListenerExceededWarning fixed!

### DIFF
--- a/inbox/test/Inbox.test.js
+++ b/inbox/test/Inbox.test.js
@@ -2,6 +2,12 @@ const assert = require('assert');
 const ganache = require('ganache-cli');
 const Web3 = require('web3');
 const web3 = new Web3(ganache.provider());
+
+//to handle memory leak
+require('events').EventEmitter.defaultMaxListeners = 15;
+
+
+
 const { interface, bytecode } = require('../compile');
 
 let accounts;


### PR DESCRIPTION
Possible EventEmitter memory leak detected. 14 data listeners are added therefore we can use the emitter.setMaxListener() to increase the limit.